### PR TITLE
fix: show about section mobile-style on medium screens with centered layout

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -60,26 +60,26 @@ function About() {
     else {
         return (
             <section id="about" className="scroll-mt-24 bg-transparent py-16">
-                <div className="max-w-7xl mx-auto px-6 lg:px-8 md:text-center md:items-center lg:text-left lg:items-start">
-                    <div className="grid lg:grid-cols-2 gap-12 items-center">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8">
+                    <div className="grid lg:grid-cols-2 gap-12 items-center md:flex md:flex-col md:items-center">
                         {/* Left Content */}
-                        <div className="space-y-6">
+                        <div className="space-y-6 md:text-center md:flex md:flex-col md:items-center">
                             <div>
-                                <h1 className="text-5xl xl:text-6xl font-extrabold tracking-tight text-gray-900 dark:text-white mb-4 leading-tight">
+                                <h1 className="text-5xl xl:text-6xl font-extrabold tracking-tight text-gray-900 dark:text-white mb-4 leading-tight md:text-center">
                                     Hi, I'm Tom!
                                 </h1>
-                                <h2 className="text-2xl xl:text-3xl font-semibold text-indigo-600 dark:text-indigo-400 mb-6">
+                                <h2 className="text-2xl xl:text-3xl font-semibold text-indigo-600 dark:text-indigo-400 mb-6 md:text-center">
                                     Full-Stack Developer & CS Student
                                 </h2>
                             </div>
                             
-                            <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed max-w-xl">
+                            <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed max-w-xl md:text-center">
                                 Final-year Computer Science student at UNB with 24 months of professional experience.
                                 I enjoy building full-stack applications, automating infrastructure, and applying machine learning to solve real problems.
                             </p>
 
                             {/* Social Links */}
-                            <div className="flex gap-4 pt-4">
+                            <div className="flex gap-4 pt-4 md:justify-center">
                                 <a
                                     href="https://github.com/t0mtait"
                                     className="inline-flex items-center gap-3 px-8 py-3.5 text-base font-medium text-gray-900 dark:text-white bg-white dark:bg-white/10 border border-gray-300 dark:border-white/30 rounded-lg hover:bg-gray-50 dark:hover:bg-white/20 hover:border-indigo-500 dark:hover:border-indigo-400 transition-all duration-300 shadow-lg hover:shadow-xl hover:scale-105"
@@ -102,12 +102,12 @@ function About() {
                         </div>
 
                         {/* Right Image */}
-                        <div className="flex justify-center lg:justify-end">
+                        <div className="flex justify-center lg:justify-end md:mt-8">
                             <div className="relative">
                                 <img 
                                     src="tomtait.png" 
                                     alt="Tom Tait" 
-                                    className="rounded-2xl w-full max-w-md shadow-2xl border border-gray-300 dark:border-white/10 hover:scale-105 transition-transform duration-300"
+                                    className="rounded-2xl w-full max-w-md shadow-2xl border border-gray-300 dark:border-white/10 hover:scale-105 transition-transform duration-300 md:max-w-sm"
                                 />
                             </div>
                         </div>

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -60,7 +60,7 @@ function About() {
     else {
         return (
             <section id="about" className="scroll-mt-24 bg-transparent py-16">
-                <div className="max-w-7xl mx-auto px-6 lg:px-8">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 md:text-center md:items-center lg:text-left lg:items-start">
                     <div className="grid lg:grid-cols-2 gap-12 items-center">
                         {/* Left Content */}
                         <div className="space-y-6">


### PR DESCRIPTION
On medium screens the logo drops below the about text, leaving awkward empty space.

Changed the grid to md:flex md:flex-col md:items-center so text and image stack vertically with everything centered — same layout as mobile, just scaled up.

Added md:text-center to headings and paragraphs, md:justify-center to social links, and md:mt-8 md:max-w-sm to the image container.