### PR TITLE
Nightly dev: add node_modules/.cache to .gitignore (2026-05-02)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,4 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .yarn/install-state.gz
-.pnp.*
+.pnp.*node_modules/.cache/


### PR DESCRIPTION
## Summary

Chore from nightly dev cycle (2026-05-02):

- Added node_modules/.cache/ to .gitignore to prevent ESLint cache from showing as modified in git status

---
*Auto-generated by nightly-dev cycle*.