### PR TITLE
fix: remove trailing whitespace from img tags

### DIFF
--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -71,8 +71,8 @@ function Experience() {
                     {/* Logo */}
                     <div className={`flex-shrink-0 ${isMobile ? 'w-full flex justify-center mb-2' : ''}`}>
                         <div className="bg-gray-900 dark:bg-gray-800 p-4 rounded-lg border border-gray-300 dark:border-transparent">
-                            <img 
-                                src={experience.logo} 
+                            <img
+                                src={experience.logo}
                                 alt={`${experience.company} logo`}
                                 className={experience.logoClasses}
                             />

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -54,8 +54,8 @@ function Projects() {
             <div className="bg-white dark:bg-white/5 backdrop-blur-sm border border-gray-200 dark:border-white/10 rounded-xl overflow-hidden hover:bg-gray-50 dark:hover:bg-white/10 hover:border-indigo-400 dark:hover:border-indigo-400/30 transition-all duration-300 shadow-lg hover:shadow-2xl hover:scale-[1.02]">
                 {/* Project Image */}
                 <div className="relative overflow-hidden bg-gray-900">
-                    <img 
-                        src={project.image} 
+                    <img
+                        src={project.image}
                         alt={`${project.title} screenshot`}
                         className={`w-full transition-transform duration-500 group-hover:scale-110 ${
                             project.title === "SupplementDB"


### PR DESCRIPTION
## Summary
Removed trailing whitespace from img tags in Experience.js and Projects.js components during code review.

## Changes
- `src/components/Experience.js` — removed trailing whitespace from img tag
- `src/components/Projects.js` — removed trailing whitespace from img tag

## Verification
- Build: Compiled successfully with no errors
- Tests: All 3 tests pass
- No console errors, broken imports, or security issues found